### PR TITLE
fix/ohl-zero-after-stock-split_220726

### DIFF
--- a/_utils.py
+++ b/_utils.py
@@ -1,6 +1,7 @@
 import re
 from datetime import datetime
-from pandas import to_datetime
+from pandas import DataFrame, to_datetime
+
 
 def _convert_letter_to_num(str_num):
     powers = {'B': 10 ** 9, 'M': 10 ** 6, 'K': 10 ** 3, '': 1}
@@ -11,6 +12,7 @@ def _convert_letter_to_num(str_num):
         return float(val) * powers[mag]
     return 0.0
 
+
 def _validate_dates(start, end):
     start = to_datetime(start)
     end = to_datetime(end)
@@ -20,3 +22,34 @@ def _validate_dates(start, end):
     if end is None:
         end = datetime.today()
     return start, end
+
+
+def _filter_by_date(df: DataFrame, start, end):
+    """
+    Retrieves a dataframe based on a given start and end date.
+
+    :param df: an original dataframe
+    :param start: start date
+    :param end: end date
+    """
+    date_query = 'index>=%r and index<=%r'
+    filtered_df = df.query(date_query % (start, end))
+    return filtered_df
+
+
+def _replace_ohl_0_with_c(df: DataFrame):
+    """
+    Due to events such as stock split,
+    if there is a row with no trading volume
+    and the closing price of the previous day is maintained,
+    it is replaced with an ohl value.
+
+    :param df: an original dataframe
+    """
+    is_trading_holiday = df['Volume'] == 0
+
+    replace_target_columns = ['Open', 'High', 'Low']
+    replace_value = df['Close']
+
+    df.loc[is_trading_holiday, replace_target_columns] = replace_value
+    return df

--- a/naver/data.py
+++ b/naver/data.py
@@ -2,7 +2,9 @@ import re
 import requests
 import pandas as pd
 from io import StringIO
-from FinanceDataReader._utils import (_convert_letter_to_num, _validate_dates)
+from FinanceDataReader._utils import (
+    _filter_by_date, _replace_ohl_0_with_c, _validate_dates)
+
 
 class NaverDailyReader:
     def __init__(self, symbol, start=None, end=None, exchange=None, data_source=None):
@@ -19,11 +21,16 @@ class NaverDailyReader:
         if len(data_list) == 0:
             return pd.DataFrame()
         data = '\n'.join(data_list)
-        df = pd.read_csv(StringIO(data), delimiter='|', header=None, dtype={0:str})
-        df.columns  = ['Date', 'Open', 'High', 'Low', 'Close', 'Volume']
+        df = pd.read_csv(StringIO(data), delimiter='|',
+                         header=None, dtype={0: str})
+        df.columns = ['Date', 'Open', 'High', 'Low', 'Close', 'Volume']
         df['Date'] = pd.to_datetime(df['Date'], format='%Y%m%d')
         df.set_index('Date', inplace=True)
         df.sort_index(inplace=True)
         df['Change'] = df['Close'].pct_change()
 
-        return df.query('index>=%r and index<=%r' % (self.start, self.end))
+        df = _filter_by_date(df, self.start, self.end)
+
+        df = _replace_ohl_0_with_c(df)
+
+        return df


### PR DESCRIPTION
Issue 해결 (#134)

주식분할로 인한 매매거래정지기간 일정에 따라, 거래량이 0(`Volume == 0`)이면 해당 종가로 유지

Ex.
- 펄어비스(`263750` `2021-04-13 ~ 2021-04-15` )
- 카카오(`035720` `2021-04-12 ~ 2021-04-14` )
- 휴스틸(`005010` `2022-06-24 ~ 2022-07-12`)